### PR TITLE
fix: parse "Profile Photo" as well as "Profile photo" (capital p)

### DIFF
--- a/memento_mori/loader.py
+++ b/memento_mori/loader.py
@@ -75,14 +75,20 @@ class InstagramDataLoader:
                 self.profile_data = json.load(f)
 
             string_map = self.profile_data["profile_user"][0]["string_map_data"]
+            media_map = self.profile_data["profile_user"][0]["media_map_data"]
 
             profile_info = {
                 "username": string_map["Username"]["value"],
-                "profile_picture": self.profile_data["profile_user"][0]["media_map_data"]["Profile photo"]["uri"],
+                "profile_picture": "",
                 "bio": "",
                 "website": "",
                 "name": "",
             }
+
+            if "Profile photo" in media_map:
+                profile_info["profile_picture"] = media_map["Profile photo"]["uri"]
+            elif "Profile Photo" in media_map:
+                profile_info["profile_picture"] = media_map["Profile Photo"]["uri"]
 
             if "Name" in string_map:
                 profile_info["name"] = string_map["Name"]["value"]


### PR DESCRIPTION
in my export, I have "Profile Photo" (both capital P)

have suggested a change to parsing to allow this and also "Profile photo" (which I assume is the old output)

```bash
$ cat instagram-alifeeerenn-2026-04-01-aTlotDyx/personal_information/personal_information/personal_information.json | grep Profile
        "Profile Photo": {
```