### PR TITLE
Fixing output when using Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Keep Instagram exports and generated output out of the image.
+# They are reached at runtime via the /app/workspace volume mount;
+# baking them in bloats the image and leaves stale copies that
+# shadow the real files on the host.
+instagram*/
+output/
+test-out/
+*.zip
+*.7z
+*.tar
+*.gz
+
+.git/
+venv/
+__pycache__/
+*.py[cod]
+.DS_Store
+comments-test/
+deprecated_php_utility/
+preview.gif

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
+# Make the package importable even when the container runs from a
+# different working directory (docker-compose uses /app/workspace)
+ENV PYTHONPATH=/app
+
 # Create directories for input/output
 RUN mkdir -p /input /output
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ docker compose build
 # Run with default settings
 docker compose run --rm memento-mori
 
-# Run with specific arguments
-docker compose run --rm memento-mori --output /output/my-site --quality 90
+# Run with specific arguments (relative paths refer to the project folder)
+docker compose run --rm memento-mori --input ./your-export-folder --output ./my-site --quality 90
 
 # Add Google Analytics tracking
 docker compose run --rm memento-mori --gtag-id G-DX1ZWTC9NZ

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
 services:
   memento-mori:
     build: .
+    # Run from the mounted project folder so relative --input/--output paths
+    # (and the ./output default) resolve on the host, not inside the container.
+    # Note: any args passed to `docker compose run` REPLACE `command:` below,
+    # so the CLI defaults must do the right thing on their own.
+    working_dir: /app/workspace
     volumes:
       - ./:/app/workspace
       - ./output:/output
     environment:
       - PYTHONUNBUFFERED=1
-    command: --search-dir /app/workspace --output /output
+    command: --search-dir . --output ./output


### PR DESCRIPTION
When using Docker, the output files were being written internally in the app/workspace. These changes make sure the output is written to the project folder (or as specified in the cli). It also cleans up the Docker image, making sure source files and output files aren't included. This may fix issue #22 . 